### PR TITLE
Prevent non-negative sleep length

### DIFF
--- a/app/operation/operation.py
+++ b/app/operation/operation.py
@@ -691,6 +691,8 @@ class ServerOperation(object):
             # todo make async
             if self._operation.delay != 0 or self._operation.jitter != 0:
                 wait_time = self._operation.delay + random.uniform(-1 * self._operation.jitter, self._operation.jitter)
+                if wait_time < 0:
+                    wait_time = self._operation.delay
                 time.sleep(wait_time / 1000)
 
         # BSF logging: build a step event for this step


### PR DESCRIPTION
As there is no validation `delay` has to be above than `jitter`, `ValueError` exception can be occurred when `delay` is lower than `jitter`. 

Example:
```python
>>> import time
>>> time.sleep(-1)
Traceback (most recent call last):
  File "/usr/lib/python3.6/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
ValueError: sleep length must be non-negative
```

This PR prevents this exception.